### PR TITLE
Fix travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: sh
+language: generic
 
 branches:
   only:
@@ -9,14 +9,15 @@ branches:
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-$TRAVIS_OS-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - source "$HOME/miniconda/etc/profile.d/conda.sh"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
   - conda config --append channels conda-forge
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION ffmpeg coverage python-coveralls --file=requirements.txt --file=requirements_test.txt
-  - source activate test-environment
+  - conda create -q -n test-environment python=$PYTHON_VERSION ffmpeg coverage python-coveralls --file=requirements.txt --file=requirements_test.txt
+  - conda activate test-environment
+  - pytest --version
 
 script: pytest --cov pya/
 after_success:
@@ -26,23 +27,19 @@ env:
   global:
     AUDIODEV=null
 
-include: &LINUX
-  os: linux
-  addons:
-    apt:
-      packages:
-        - portaudio19-dev
-  env:
-    - TRAVIS_OS=Linux
-
-include: &OSX
-  os: osx
-  env:
-    - TRAVIS_OS=MacOSX
-
-matrix:
+jobs:
   include:
-    - <<: *LINUX
+    - os: linux
       python: 3.7
-    - <<: *OSX
+      addons:
+        apt:
+          packages:
+            - portaudio19-dev
+      env:
+        - TRAVIS_OS=Linux
+        - PYTHON_VERSION=3.7
+    - os: osx
       python: 3.7
+      env:
+        - TRAVIS_OS=MacOSX
+        - PYTHON_VERSION=3.7

--- a/pya/backend/Jupyter.py
+++ b/pya/backend/Jupyter.py
@@ -84,7 +84,7 @@ var channels = {self.channels};
 var urlSuffix = "{url_suffix}";
 window.pya = {{ bufferThresh: 0.2 }}
             """
-            """
+            r"""
 var processedPackages = 0;
 var latePackages = 0;
 var badPackageRatio = 1;


### PR DESCRIPTION
Travis was previously built with the default Python version as $TRAVIS_PYTHON_VERSION seems to be empty in generic/shell projects even when Python version is specified in the job configuration.