### PR TITLE
Ft/add aserver context

### DIFF
--- a/pya/asig.py
+++ b/pya/asig.py
@@ -614,7 +614,7 @@ class Asig:
                 new_sig[:, i] = interp_fn(tsel)
             return Asig(new_sig, target_sr, label=self.label + "_resampled", cn=self.cn)
 
-    def play(self, rate=1, **kwargs):
+    def play(self, rate=1, server=None, onset=0, channel=0, block=False):
         """Play Asig audio via Aserver, using Aserver.default (if existing)
         kwargs are propagated to Aserver:play(onset=0, out=0)
 
@@ -631,10 +631,7 @@ class Asig:
         _ : Asig
             return self
         """
-        if "server" in kwargs.keys():
-            s = kwargs["server"]
-        else:
-            s = Aserver.default
+        s = server or Aserver.default
         if not isinstance(s, Aserver):
             warn("Asig.play: no default server running, nor server arg specified.")
             return self
@@ -642,7 +639,7 @@ class Asig:
             asig = self
         else:
             asig = self.resample(s.sr, rate)
-        s.play(asig, **kwargs)
+        s.play(asig, server=s, onset=onset, out=channel, block=block)
         return self
 
     def shift_channel(self, shift=0):

--- a/pya/asig.py
+++ b/pya/asig.py
@@ -105,11 +105,6 @@ class Asig:
             return 1
 
     @property
-    def samples(self):
-        """Return the length of signal in samples"""
-        return np.shape(self.sig)[0]
-
-    @property
     def cn(self):
         """Channel names getter"""
         return self._cn
@@ -132,6 +127,20 @@ class Asig:
                     "list size doesn't match channel numbers {}".format(
                         self.channels)
                 )
+
+    @property
+    def samples(self) -> int:
+        """
+        Return the length of signal in samples
+        """
+        return np.shape(self.sig)[0]
+
+    @property
+    def dur(self) -> float:
+        """
+        Return the duration in seconds
+        """
+        return self.samples / self.sr
 
     def _load_audio_file(self, fname):
         """Load audio file, and set self.sig to the signal

--- a/pya/backend/PyAudio.py
+++ b/pya/backend/PyAudio.py
@@ -50,4 +50,6 @@ class PyAudioBackend(BackendBase):
         return buffer, pyaudio.paContinue
 
     def terminate(self):
-        self.pa.terminate()
+        if self.pa:
+            self.pa.terminate()
+            self.pa = None

--- a/tests/test_asig.py
+++ b/tests/test_asig.py
@@ -39,6 +39,9 @@ class TestAsig(TestCase):
                                                    (self.asine.samples - 1) / self.asine.sr,
                                                    self.asine.samples), self.asine.get_times()))
 
+    def test_dur_property(self):
+        self.assertEqual(self.asine.dur, 1.)
+
     def test_fader(self):
         result = self.asine.fade_in(dur=0.2)
         self.assertIsInstance(result, Asig)


### PR DESCRIPTION
Making Aserver a context allows auto cleanup. Useful in case where you don't want the stream to be always running in runtime. e.g. 
```
with Aserver() as s:
    asig.play(server=s)
```
This context will handle boot and stop for you. 

Another change in this PR is to make play argument more explicit. This will make writing the code easier than using **kwargs since it now provides specific hinting and auto completion.