### PR TITLE
Replace Sanic with Websockets for Jupyter Backend

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,4 +8,4 @@ dependencies:
 - ipywidgets
 - requests
 - notebook
-- sanic
+- websockets

--- a/examples/pya-examples.ipynb
+++ b/examples/pya-examples.ipynb
@@ -46,10 +46,13 @@
    "outputs": [],
    "source": [
     "# Boot up the audio server\n",
-    "# Aserver(sr=44100, bs=256, device=None, channels=2, backend=None, format=pyaudio.paFloat32)\n",
-    "# By default pya will try to use PyAudio as the audio backend\n",
-    "# If buffer size is not passed it will be determined by the backend\n",
-    "s = Aserver(backend=auto_backend)  \n",
+    "# e.g. with Aserver(sr=44100, bs=256, device=None, channels=2, backend=None, format=pyaudio.paFloat32)\n",
+    "# By default pya will try to use PyAudio as the audio backend.\n",
+    "# If buffer size is not passed it will be determined by the backend.\n",
+    "# Note that a larger buffer size (bs) might cause lag when playing audio.\n",
+    "# However, a small buffer might cause stutter, especially when the WebAudio/Jupyter backend is used.\n",
+    "# The default values should suffice for most use cases.\n",
+    "s = Aserver(backend=auto_backend)\n",
     "Aserver.default = s  # set default Aserver to use play() w/o explicit arg\n",
     "s.boot()"
    ]

--- a/examples/pya-examples.ipynb
+++ b/examples/pya-examples.ipynb
@@ -17,9 +17,7 @@
     "# This part only makes sure that the repository version of pya is used for this notebook ...\n",
     "import os, sys, inspect, io\n",
     "\n",
-    "cmd_folder = os.path.realpath(\n",
-    "    os.path.dirname(\n",
-    "        os.path.abspath(os.path.split(inspect.getfile( inspect.currentframe() ))[0])))\n",
+    "cmd_folder = os.path.abspath(sys.path[0] + \"/../\")\n",
     "\n",
     "if cmd_folder not in sys.path:\n",
     "    sys.path.insert(0, cmd_folder)\n",
@@ -2108,7 +2106,7 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2122,7 +2120,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.14"
   },
   "toc": {
    "base_numbering": 1,

--- a/pya/aserver.py
+++ b/pya/aserver.py
@@ -78,7 +78,7 @@ class Aserver:
             self.backend = PyAudioBackend(**kwargs)
         else:
             self.backend = backend
-        self.bs = bs if bs is not None else self.backend.bs
+        self.bs = bs or self.backend.bs
         self.channels = channels
         # Get audio devices to input_device and output_device
         self.input_devices = []

--- a/pya/aserver.py
+++ b/pya/aserver.py
@@ -73,12 +73,12 @@ class Aserver:
         """
         # TODO check if channels is overwritten by the device.
         self.sr = sr
-        self.bs = bs
         if backend is None:
             from .backend.PyAudio import PyAudioBackend
             self.backend = PyAudioBackend(**kwargs)
         else:
             self.backend = backend
+        self.bs = bs if bs is not None else self.backend.bs
         self.channels = channels
         # Get audio devices to input_device and output_device
         self.input_devices = []

--- a/pya/aserver.py
+++ b/pya/aserver.py
@@ -48,7 +48,7 @@ class Aserver:
         else:
             warn("Aserver:shutdown_default_server: no default_server to shutdown")
 
-    def __init__(self, sr=44100, bs=512, device=None,
+    def __init__(self, sr=44100, bs=None, device=None,
                  channels=2, backend=None, **kwargs):
         """Aserver manages an pyaudio stream, using its aserver callback
         to feed dispatched signals to output at the right time.
@@ -58,7 +58,7 @@ class Aserver:
         sr : int
             Sampling rate (Default value = 44100)
         bs : int
-            block size or buffer size (Default value = 256)
+            Override block size or buffer size set by chosen backend
         device : int
             The device index based on pya.device_info(), default is None which will set 
             the default device from PyAudio

--- a/requirements_remote.txt
+++ b/requirements_remote.txt
@@ -1,3 +1,3 @@
 notebook
-sanic
+websockets
 ipywidgets


### PR DESCRIPTION
This fixes #62.

Besides changes to the aforementioned backend this also roles back some (accidental?) changes in Aserver and extends the Jupyter Notebook documentation about Aserver's buffer size.

The most remarkable change would be that `Aserver.__init__` now has `bs=None` as a default argument so that backend default values can be considered.

