### PR TITLE
Python310 support

### DIFF
--- a/.github/workflows/pya-ci.yaml
+++ b/.github/workflows/pya-ci.yaml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install portaudio Ubuntu
       if: matrix.os == 'ubuntu-latest'
       shell: bash -l {0}
@@ -38,7 +38,9 @@ jobs:
       run: |
         conda init bash
         conda activate test-env
-        conda install ffmpeg coverage python-coveralls --file=requirements.txt --file=requirements_remote.txt --file=requirements_test.txt
+        conda install ffmpeg coverage python-coveralls --file=requirements_remote.txt --file=requirements_test.txt
+        # pyaudio is not yet available on conda
+        pip install -r requirements.txt
     - name: Run tests
       shell: bash -l {0}
       run: |

--- a/README.md
+++ b/README.md
@@ -40,29 +40,42 @@ At this time pya is more suitable for offline rendering than realtime.
 
 ## Authors and Contributors
 
-* Thomas Hermann, Ambient Intelligence Group, Faculty of Technology, Bielefeld University (author and maintainer)
-* Jiajun Yang, Ambient Intelligence Group, Faculty of Technology, Bielefeld University (co-author)
-* Alexander Neumann, Neurocognitions and Action - Biomechanics, Bielefeld University
+* [Thomas](https://github.com/thomas-hermann) (author, maintainer)
+* [Jiajun](https://github.com/wiccy46) (co-author, maintainer)
+* [Alexander](https://github.com/aleneum) (maintainer)
 * Contributors will be acknowledged here, contributions are welcome.
 
 ## Installation
 
-<!-- **Disclaimer**: We are currently making sure that pya can be uploaded to PyPI, until then clone the master branch and from inside the pya directory install via `pip install -e .` -->
+`pya` requires `portaudio` to play and record audio. 
 
-**Note**: pya can be installed using **pip**. But pya uses PyAudio for audio playback and record, and PyAudio 0.2.11 has yet to fully support Python 3.7. So using pip install with Python 3.7 may encounter issues such as portaudio. Solutions are:
+1. Disclaimer: As of December 2022, the latest `pyaudio==0.2.12` is not fully available on Conda Forge. This means 
+this methods is currently not suitable, as it will install 0.2.11 instead. This will work on older version of Pya (< 0.5.1). 
 
-1. Anaconda can install non-python packages, so that the easiest way (if applicable) would be to 
+Anaconda can install non-python packages, so that the easiest way (if applicable) would be to 
 
     conda install pyaudio
 
-2. For Mac users, you can `brew install portaudio` beforehand. 
+
+2. For Mac users, `brew install portaudio`.
+  - For Apple ARM Chip, do the following instead: [Installation on ARM chip](https://stackoverflow.com/a/73166852/4930109)
+      - `brew install portaudio`
+      - `brew --prefix poraudio`
+      - Create .pydistutils.cfg in your home directory, `~/.pydistutils.cfg`, add:
+
+```
+[build_ext]
+include_dirs=<PATH FROM STEP 3>/include/
+library_dirs=<PATH FROM STEP 3>/lib/
+```
+      - `pip install -r requirements.txt`
 
 3. For Linux users, try `sudo apt-get install portaudio19-dev` or equivalent to your distro.
 
 4. For Windows users, you can install PyAudio wheel at:
 https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyaudio
 
-Then pya can be installed using pip:
+Then pya can be installed using pip (or just use the requirements.txt):
 
     pip install pya
 
@@ -140,8 +153,9 @@ The benefit of this is that it will handle server bootup and shutdown for you. B
 
 ```Python
 from pya import find_device
+from pya import Aserver
 devices = find_device() # This will return a dictionary of all devices, with their index, name, channels.
-s = pya.Aserver(sr=48000, bs=256, device=devices['name_of_your_device']['index'])
+s = Aserver(sr=48000, bs=256, device=devices['name_of_your_device']['index'])
 ```
 
 
@@ -167,6 +181,24 @@ to plot the spectrogram via the Astft class
 * Asigs support multi-channel audio (as columns of the signal array)
   * `a1[:100, :3]` would select the first 100 samples and the first 3 channels, 
   * `a1[{1.2:2}, ['left']]` would select the channel named 'left' using a time slice from 1
+
+### Recording from Device
+
+`Arecorder` allows recording from input device 
+
+```Python
+import time
+
+from pya import find_device
+from pya import Arecorder
+devices = find_device()  # Find the index of the input device
+arecorder = Arecorder(device=some_index, sr=48000, bs=512)  # Or not set device to let pya find the default device 
+arecorder.boot()
+arecorder.record()
+time.sleep(2)  # Recording is non-blocking
+arecorder.stop()
+last_recording = arecorder.recordings[-1]  # Each time a recorder stop, a new recording is appended to recordings
+```
 
 ### Method chaining
 Asig methods usually return an Asig, so methods can be chained, e.g

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,9 @@ install:
   - conda update -q conda
   - conda info -a
   - conda config --append channels conda-forge
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% ffmpeg coverage --file=requirements.txt --file=requirements_remote.txt --file=requirements_test.txt"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% ffmpeg coverage --file=requirements_remote.txt --file=requirements_test.txt"
   - activate test-environment
+  - "pip install -r requirements.txt"
 
 test_script:
   - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-scipy==1.7.3
-matplotlib==3.5.3
-pyaudio>=0.2.11  # Portaudio is required beforehand, for linux: sudo apt-get install libasound-dev
+scipy>=1.7.3
+matplotlib>=3.5.3
+pyaudio>=0.2.12  # Portaudio is required beforehand, for linux: sudo apt-get install libasound-dev
 # Since portaudio is not a python package, the easiest way is to use Anaconda, conda install pyaudio
 # This will install both portaudio and pyaudio


### PR DESCRIPTION
This addresses #58

On my intel and arm mac Python3.10 support seems to be a straightforward bump. But arm mac needs some walkaround to install `portaudio`