### PR TITLE
Bugfix/aserver arecorder channels not reflecting actual device

### DIFF
--- a/pya/arecorder.py
+++ b/pya/arecorder.py
@@ -39,8 +39,8 @@ class Arecorder(Aserver):
         self._record_all = True
         self.gains = np.ones(self.channels)
         self.tracks = slice(None)
-        self.device = device or self.backend.get_default_input_device_info()['index']
-        self.channels = channels or self.backend.get_default_input_device_info()['maxInputChannels']
+        self._device = device or self.backend.get_default_input_device_info()['index']
+        self.channels = channels or self.backend.get_device_info_by_index(self._device)['maxInputChannels']
 
     def set_tracks(self, tracks, gains):
         """Define the number of track to be recorded and their gains.

--- a/pya/aserver.py
+++ b/pya/aserver.py
@@ -48,8 +48,8 @@ class Aserver:
         else:
             warn("Aserver:shutdown_default_server: no default_server to shutdown")
 
-    def __init__(self, sr=44100, bs=512, device=None,
-                 channels=2, backend=None, **kwargs):
+    def __init__(self, sr=44100, bs=None, device=None,
+                 channels=None, backend=None, **kwargs):
         """Aserver manages an pyaudio stream, using its aserver callback
         to feed dispatched signals to output at the right time.
 
@@ -79,7 +79,6 @@ class Aserver:
         else:
             self.backend = backend
         self.bs = bs or self.backend.bs
-        self.channels = channels
         # Get audio devices to input_device and output_device
         self.input_devices = []
         self.output_devices = []
@@ -90,6 +89,7 @@ class Aserver:
                 self.output_devices.append(self.backend.get_device_info_by_index(i))
 
         self._device = device or self.backend.get_default_output_device_info()['index']
+        self.channels = channels or self.backend.get_device_info_by_index(self.device)['maxOutputChannels']
 
         self.gain = 1.0
         self.srv_onsets = []

--- a/pya/backend/Dummy.py
+++ b/pya/backend/Dummy.py
@@ -10,9 +10,8 @@ class DummyBackend(BackendBase):
     range = 1
     bs = 256
 
-    def __init__(self, dummy_devices=None):
-        if dummy_devices is None:
-            self.dummy_devices = [dict(maxInputChannels=10, maxOutputChannels=10, index=0, name="DummyDevice")]
+    def __init__(self):
+        self.dummy_devices = [dict(maxInputChannels=10, maxOutputChannels=10, index=0, name="DummyDevice")]
 
     def get_device_count(self):
         return len(self.dummy_devices)
@@ -27,6 +26,9 @@ class DummyBackend(BackendBase):
         return self.dummy_devices[0]
 
     def open(self, *args, input_flag, output_flag, rate, frames_per_buffer, channels, stream_callback=None, **kwargs):
+        checker = 'maxInputChannels' if input_flag else 'maxOutputChannels'
+        if channels > self.dummy_devices[0][checker]:
+            raise OSError("[Errno -9998] Invalid number of channels")
         stream = DummyStream(input_flag=input_flag, output_flag=output_flag, 
                              rate=rate, frames_per_buffer=frames_per_buffer, channels=channels,
                              stream_callback=stream_callback)

--- a/tests/test_arecorder.py
+++ b/tests/test_arecorder.py
@@ -1,10 +1,12 @@
 # Test arecorder class.
+import random
 import time
 from pya import Arecorder, Aserver, find_device
 from unittest import TestCase, skipUnless, mock, skip, expectedFailure
 import pytest
 import pyaudio
-import time
+
+from pya.backend.Dummy import DummyBackend
 
 # check if we have an output device
 has_input = False
@@ -76,13 +78,20 @@ class MockRecorder(mock.MagicMock):
 
 
 class TestArecorderBase(TestCase):
-
     __test__ = False
     backend = None
+    max_inputs = backend.dummy_devices[0]['maxInputChannels'] if backend else 0
 
-    @pytest.mark.xfail(reason="Test may get affect with PortAudio bug or potential unsuitable audio device.")
+    @pytest.mark.xfail(reason="Test may get affected by PortAudio bug or potential unsuitable audio device.")
+    def test_boot(self):
+        ar = Arecorder(backend=self.backend).boot()
+        self.assertTrue(ar.is_active)
+        ar.quit()
+        self.assertFalse(ar.is_active)
+
+    @pytest.mark.xfail(reason="Test may get affected by PortAudio bug or potential unsuitable audio device.")
     def test_arecorder(self):
-        ar = Arecorder(channels=1, backend=self.backend).boot()
+        ar = Arecorder(channels=1, backend=None).boot()
         self.assertEqual(ar.sr, 44100)
         ar.record()
         time.sleep(1.)
@@ -97,7 +106,7 @@ class TestArecorderBase(TestCase):
         ar.recordings.clear()
         ar.quit()
 
-    @pytest.mark.xfail(reason="Test may get affect with PortAudio bug or potential unsuitable audio device.")
+    @pytest.mark.xfail(reason="Test may get affected by PortAudio bug or potential unsuitable audio device.")
     def test_combined_inout(self):
         # test if two streams can be opened on the same device
         # can only be tested when a device with in- and output capabilities is available
@@ -114,18 +123,45 @@ class TestArecorderBase(TestCase):
             player.boot()
             recorder.boot()  # initialized record and boot sequentially to provoke racing condition
             recorder.record()
-            time.sleep(1.)  # wait and record some samples
+            time.sleep(1.)
             recorder.stop()
             player.quit()
             self.assertEqual(len(recorder.recordings), 1)  # we should have one Asig recorded
-            # check whether a realistic amount of samples has been recorded
-            # we assume that a recording ten times the buffer size is a fair indicator of a working process
-            self.assertGreater(recorder.recordings[0].sig.shape[0], 10 * bs)
+            self.assertGreater(recorder.recordings[0].sig.shape[0], 10 * bs, 
+                               "Recording length is too short, < 10buffers")
             recorder.quit()
+
+    @pytest.mark.xfail(reason="Test may get affected by PortAudio bug or potential unsuitable audio device.")
+    def test_custom_channels(self):
+        s = Arecorder(channels=self.max_inputs, backend=self.backend)
+        s.boot()
+        self.assertTrue(s.is_active)
+        s.quit()
+        self.assertFalse(s.is_active)
+
+    @pytest.mark.xfail(reason="Test may get affected by PortAudio bug or potential unsuitable audio device.")
+    def test_invalid_channels(self):
+        """Raise an exception if booting with channels greater than max channels of the device. Dummy has 10"""
+        if self.backend:
+            s = Arecorder(channels=self.max_inputs + 1, backend=self.backend)
+            with self.assertRaises(OSError):
+                s.boot()
+        else:
+            s = Arecorder(channels=-1, backend=self.backend)
+            with self.assertRaises(ValueError):
+                s.boot()
+
+    @pytest.mark.xfail(reason="Some devices may not have inputs")
+    def test_default_channels(self):
+        if self.backend:
+            s = Arecorder(backend=self.backend)
+            self.assertEqual(s.channels, self.backend.dummy_devices[0]['maxInputChannels'])
+        else:
+            s = Arecorder()
+            self.assertGreater(s.channels, 0, "No input channel found")
 
 
 class TestArecorder(TestArecorderBase):
-
     __test__ = True
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,9 +1,9 @@
 from .helpers import wait
 from .test_play import TestPlayBase
 from .test_arecorder import TestArecorderBase
+from pya import Arecorder
 from pya.backend import DummyBackend
 from unittest import TestCase, skipUnless
-import time
 
 try:
     from pya.backend import JupyterBackend


### PR DESCRIPTION
This addresses #67 

I also made some changes to the unit tests. 

- I added a mock behavior to Dummy if channels more than maxInputChannels/maxOutputChannels, raise the same OSError. 
- Remove dummy_devices arg as it doesn't seem necessary. 
- Add test cases with channels using DummyBackend. 