### PR TITLE
select correct device if index == 0

### DIFF
--- a/pya/arecorder.py
+++ b/pya/arecorder.py
@@ -39,7 +39,7 @@ class Arecorder(Aserver):
         self._record_all = True
         self.gains = np.ones(self.channels)
         self.tracks = slice(None)
-        self._device = device or self.backend.get_default_input_device_info()['index']
+        self._device = self.backend.get_default_input_device_info()['index'] if device is None else device
         self.channels = channels or self.backend.get_device_info_by_index(self._device)['maxInputChannels']
 
     def set_tracks(self, tracks, gains):

--- a/pya/aserver.py
+++ b/pya/aserver.py
@@ -88,7 +88,7 @@ class Aserver:
             if int(self.backend.get_device_info_by_index(i)['maxOutputChannels']) > 0:
                 self.output_devices.append(self.backend.get_device_info_by_index(i))
 
-        self._device = device or self.backend.get_default_output_device_info()['index']
+        self._device = self.backend.get_default_input_device_info()['index'] if device is None else device
         self.channels = channels or self.backend.get_device_info_by_index(self.device)['maxOutputChannels']
 
         self.gain = 1.0


### PR DESCRIPTION
this PR fixes [Issue #75](https://github.com/interactive-sonification/pya/issues/75) (Arecorder uses default device when 0 is used a input)