### PR TITLE
Fix plotting with custom axis

### DIFF
--- a/pya/helper/visualization.py
+++ b/pya/helper/visualization.py
@@ -28,7 +28,8 @@ def basicplot(data: np.ndarray, ticks, channels, offset=0, scale=1,
             Plot type.
 
     """
-    ax = ax or plt.gca()
+    # Fallback to current axis if no axis provided
+    ax = ax if ax else plt.gca()
     if channels == 1 or (offset == 0 and scale == 1):
         # if mono signal or you would like to stack signals together
         # offset is the spacing between channel,

--- a/pya/helper/visualization.py
+++ b/pya/helper/visualization.py
@@ -28,7 +28,7 @@ def basicplot(data: np.ndarray, ticks, channels, offset=0, scale=1,
             Plot type.
 
     """
-    ax = plt.gca() or ax
+    ax = ax or plt.gca()
     if channels == 1 or (offset == 0 and scale == 1):
         # if mono signal or you would like to stack signals together
         # offset is the spacing between channel,


### PR DESCRIPTION
Previously, the `.helper.basicplot` function, which is used by the `Asig.plot` method, would always use the current axis from `plt.gca()`, and ignore the `ax` argument even if provided. This pull request includes a fix so that `ax` is always used if provided, and `plt.gca()` is only used as a fallback in case `ax` did not previously exist.

## Demonstration code
```py
import matplotlib.pyplot as plt
from pya.agen.lib import LFSaw
import numpy as np

fig = plt.figure(figsize=(12, 3))
axs = fig.subplots(1, 4).flat

for i, ax in enumerate(axs):
  LFSaw(440*2**i).gen_asig(400).plot(ax=ax)
```
**Old behavior:** The code would create four subplots, but draw all the signals together on just the last subplot.

**New behavior:** The code now plots each signal on a different subplot.