### PR TITLE
Added: Modulo, functional convenience, LFImpulse AGen

### DIFF
--- a/pya/agen/core.py
+++ b/pya/agen/core.py
@@ -195,6 +195,12 @@ class AGen(ABC):
     def __rtruediv__(self, other: GenOrNum):
         return DivGen(other, self)
 
+    def __mod__(self, other: GenOrNum):
+        return ModGen(self, other)
+    
+    def __rmod__(self, other: GenOrNum):
+        return ModGen(other, self)
+
     def __and__(self, other: GenOrNum) -> ConcatGen:
         return ConcatGen(self, other)
 
@@ -759,6 +765,28 @@ class AGen(ABC):
         self.label = label
         return self
     
+    def add(self, x: GenOrNum = 0.0) -> AGen:
+        """Add x (GenOrNum to generator, equivalent to (self + x). 
+        The functional form can be easier to write and chain with other methods.
+
+        Parameters
+        ----------
+        x: GenOrNum
+            The term to be added to self (either value or generator).
+        """
+        return self + x
+    
+    def sub(self, x: GenOrNum = 0.0) -> AGen:
+        """Substract x (GenOrNum to generator, equivalent to (self - x). 
+        The functional form can be easier to write and chain with other methods.
+
+        Parameters
+        ----------
+        x: GenOrNum
+            The term to be substracted from self (either value or generator).
+        """
+        return self - x
+    
     def mul(self, x: GenOrNum = 1.0) -> AGen:
         """Multiply generator with x (GenOrNum), equivalent to (self * x). 
         The functional form can be easier to write and chain with other methods.
@@ -769,6 +797,39 @@ class AGen(ABC):
             The factor (either value or generator).
         """
         return self * x
+    
+    def div(self, x: GenOrNum = 0.0) -> AGen:
+        """Divide by x (GenOrNum to generator, equivalent to (self / x). 
+        The functional form can be easier to write and chain with other methods.
+
+        Parameters
+        ----------
+        x: GenOrNum
+            The divisor (either value or generator).
+        """
+        return self / x
+    
+    def pow(self, x: GenOrNum = 1.0) -> AGen:
+        """Power generator with x (GenOrNum), equivalent to (self ** x). 
+        The functional form can be easier to write and chain with other methods.
+
+        Parameters
+        ----------
+        x: GenOrNum
+            The exponent (either value or generator).
+        """
+        return self ** x
+    
+    def mod(self, x: GenOrNum = 0.0) -> AGen:
+        """Get modulo x (GenOrNum to generator, equivalent to (self / x). 
+        The functional form can be easier to write and chain with other methods.
+
+        Parameters
+        ----------
+        x: GenOrNum
+            The divisor (either value or generator).
+        """
+        return self % x
 
     def lvl(self, db: GenOrNum = 0) -> AGen:
         """Level generator by x (GenOrNum) where db is in dB units.
@@ -781,17 +842,6 @@ class AGen(ABC):
             The change in deciBel to be applied to self.
         """
         return self * pam.db_to_amp(db)
-    
-    def add(self, x: GenOrNum = 0.0) -> AGen:
-        """Add x (GenOrNum to generator, equivalent to (self + x). 
-        The functional form can be easier to write and chain with other methods.
-
-        Parameters
-        ----------
-        x: GenOrNum
-            The term to be added to self (either value or generator).
-        """
-        return self + x
 
     def with_done(self, done: DoneAction | str) -> AGen:
         """Wraps this AGen with another AGen with `done` as done action. """
@@ -952,6 +1002,15 @@ class AGen(ABC):
 
     def sign(self, **kwargs):
         return self.apply(np.sign, **kwargs)
+    
+    def floor(self, **kwargs):
+        return self.apply(np.floor, **kwargs)
+    
+    def ceil(self, **kwargs):
+        return self.apply(np.ceil, **kwargs)
+    
+    def round(self, *args, **kwargs):
+        return self.apply(np.round, *args, **kwargs)
 
     def sin(self, **kwargs):
         return self.apply(np.sin, **kwargs)
@@ -1491,6 +1550,28 @@ class DivGen(AGen):
 
     def _generate_new(self, sample_count: int, start: int, channel: int) -> np.ndarray:
         return self.nodes["dividend"] / self.nodes["divisor"]  # type: ignore
+
+
+class ModGen(AGen):
+    """Generator for modulo (remainder of a division) of two generators.
+    At least one of gen1 and gen2 must be an AGen.
+
+    Parameters
+    ----------
+    dividend
+        The dividend generator
+    divisor
+        The divisor generator
+    """
+
+    def __init__(self, dividend: GenOrNum, divisor: GenOrNum, *args, **kwargs):
+        super().__init__(*args, sr=None, label="%", **kwargs)
+
+        self._add_node(dividend, "dividend")
+        self._add_node(divisor, "divisor")
+
+    def _generate_new(self, sample_count: int, start: int, channel: int) -> np.ndarray:
+        return self.nodes["dividend"] % self.nodes["divisor"]  # type: ignore 
 
 
 def xgen(

--- a/pya/agen/lib.py
+++ b/pya/agen/lib.py
@@ -251,7 +251,8 @@ class LFImpulse(SingleChannelGen):
     freq
         The frequency of the oscillator in Hz. range (0Hz..Nyquist frequency).
     phase
-        The phase of the oscillator in cycles (0..1).
+        The phase of the oscillator in cycles (0..1). When modulated downwards
+        faster than the phase increase of the freq, only zero-samples are returned.
 
 
     LFImpulse will output a 1.0 on the first sample (if phase == 0).
@@ -268,30 +269,26 @@ class LFImpulse(SingleChannelGen):
         super().__init__(*args, **kwargs)
 
         self._add_node(freq, "freq", convert_num_to_arr=True)
-        self._add_node(phase, "phase")
+        self._add_node(phase, "phase", convert_num_to_arr=True)
 
     def _generate_single(self, sample_count: int, start: int = 0) -> np.ndarray:
         # To ensure first output is 1 if input phase == 0
         m_phase = self.state.data.get("m_phase", -sys.float_info.min)
+        m_input_phase = self.state.data.get("m_input_phase", self.nodes["phase"][0]) # type: ignore
 
         # Use a cumsum here to account for varying frequencies
-        #increments = np.empty(min(sample_count, self.nodes["freq"].shape[0]) + 1)
-        #increments[0] = m_phase
-        #increments[1:] = np.minimum(self.nodes["freq"], self.sr/2) / self.sr
-        #phases = np.cumsum(increments)
-
         phases = np.cumsum(
             np.concatenate(
-                [
-                    np.array([m_phase]),
-                    np.minimum(self.nodes["freq"], self.sr/2) / self.sr,
-                ]
+                ([m_phase], np.minimum(self.nodes["freq"], self.sr/2) / self.sr)
             )
         )
+        input_phases = np.concatenate(([m_input_phase], self.nodes["phase"]))
 
-        self.state.data["m_phase"] = phases[-1] % 1
-        phases = (phases + self.nodes["phase"]) % 1
-        return (phases[1:] < phases[:-1])
+        self.state.data["m_phase"] = phases[-1] % 1 # modulo for long term numeric stability
+        self.state.data["m_input_phase"] = input_phases[-1]
+        
+        floor_phases = np.floor(phases + input_phases)
+        return (floor_phases[1:] > floor_phases[:-1])
 
 
 class LFPulse(SingleChannelGen):

--- a/pya/agen/lib.py
+++ b/pya/agen/lib.py
@@ -5,6 +5,7 @@ import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Iterable, Sequence
 import threading
+import sys
 
 import numpy as np
 from pya.asig import Asig
@@ -142,15 +143,12 @@ class SinOsc(SingleChannelGen):
         The frequency of the oscillator in Hz.
     phase
         The phase of the oscillator in radians.
-    amp
-        The amplitude of the oscillator.
     """
 
     def __init__(
         self,
         freq: GenOrNum = 440.0,
         phase: GenOrNum = 0.0,
-        amp: GenOrNum = 1.0,
         *args,
         **kwargs,
     ):
@@ -158,11 +156,16 @@ class SinOsc(SingleChannelGen):
 
         self._add_node(freq, "freq", convert_num_to_arr=True)
         self._add_node(phase, "phase")
-        self._add_node(amp, "amp")
 
     def _generate_single(self, sample_count: int, start: int = 0) -> np.ndarray:
         m_phase = self.state.data.get("m_phase", 0)
         # Use a cumsum here to account for varying frequencies
+
+        # TODO: parity check + profiling
+        # increments = self.nodes["freq"] / self.sr * 2.0 * np.pi
+        # increments[0] += m_phase
+        # phases = np.cumsum(increments)
+
         phases = np.cumsum(
             np.concatenate(
                 [
@@ -171,10 +174,11 @@ class SinOsc(SingleChannelGen):
                 ]
             )
         )
+
         x = phases[:-1] + self.nodes["phase"]
         if x.shape[0] > 0:
             self.state.data["m_phase"] = phases[-1]
-        return np.sin(x) * self.nodes["amp"]
+        return np.sin(x)
 
 
 class WhiteNoise(SingleChannelGen):
@@ -245,22 +249,19 @@ class LFImpulse(SingleChannelGen):
     Parameters
     ----------
     freq
-        The frequency of the oscillator in Hz. Clips at Nyquist.
+        The frequency of the oscillator in Hz. range (0Hz..Nyquist frequency).
     phase
         The phase of the oscillator in cycles (0..1).
-    amp
-        The amplitude of the oscillator.
 
 
-    LFImpulse will output a 1.0 on the first sample (assuming no phase offset).
-    If the initial freq = 0, a single impulse is output on first sample, followed by silence until the frequency changes.
-
+    LFImpulse will output a 1.0 on the first sample (if phase == 0).
+    If the initial freq is 0, a single impulse is output on first sample, 
+    followed by silence until the frequency changes.
     """
     def __init__(
         self,
         freq: GenOrNum = 440.0,
         phase: GenOrNum = 0.0,
-        amp: GenOrNum = 1.0,
         *args,
         **kwargs,
     ):
@@ -268,29 +269,29 @@ class LFImpulse(SingleChannelGen):
 
         self._add_node(freq, "freq", convert_num_to_arr=True)
         self._add_node(phase, "phase")
-        self._add_node(amp, "amp")
 
     def _generate_single(self, sample_count: int, start: int = 0) -> np.ndarray:
-        m_phase = self.state.data.get("m_phase", 0)
+        # To ensure first output is 1 if input phase == 0
+        m_phase = self.state.data.get("m_phase", -sys.float_info.min)
 
         # Use a cumsum here to account for varying frequencies
+        #increments = np.empty(min(sample_count, self.nodes["freq"].shape[0]) + 1)
+        #increments[0] = m_phase
+        #increments[1:] = np.minimum(self.nodes["freq"], self.sr/2) / self.sr
+        #phases = np.cumsum(increments)
+
         phases = np.cumsum(
             np.concatenate(
                 [
                     np.array([m_phase]),
-                    - np.minimum(self.nodes["freq"], self.sr/2) / self.sr,
+                    np.minimum(self.nodes["freq"], self.sr/2) / self.sr,
                 ]
             )
         )
 
-        phases %= 1
-
-        if phases.shape[0] > 0:
-            self.state.data["m_phase"] = phases[-1]
-
-        phases = (phases - self.nodes["phase"]) % 1
-        # Create impulses every time the phase wraps from 0 to 1
-        return (phases[1:] > phases[:-1]) * self.nodes["amp"]
+        self.state.data["m_phase"] = phases[-1] % 1
+        phases = (phases + self.nodes["phase"]) % 1
+        return (phases[1:] < phases[:-1])
 
 
 class LFPulse(SingleChannelGen):

--- a/pya/agen/lib.py
+++ b/pya/agen/lib.py
@@ -348,15 +348,12 @@ class LFSaw(AGen):
         The frequency of the oscillator in Hz.
     phase
         The initial (normalized) phase of the oscillator [0, 1].
-    amp
-        The amplitude of the oscillator.
     """
 
     def __init__(
         self,
         freq: GenOrNum,
         phase: GenOrNum = 0.0,
-        amp: GenOrNum = 1.0,
         *args,
         **kwargs,
     ) -> None:
@@ -364,7 +361,6 @@ class LFSaw(AGen):
 
         self._add_node(freq, "freq", convert_num_to_arr=True)
         self._add_node(phase, "phase")
-        self._add_node(amp, "amp")
 
     def _generate_new(self, sample_count: int, start: int, channel: int) -> np.ndarray:
         # Use a cumsum here to account for varying frequencies
@@ -381,7 +377,7 @@ class LFSaw(AGen):
         x = phases[:-1] + self.nodes["phase"]
         if x.shape[0] > 0:
             self.state.data["m_phase"] = phases[-1]
-        return (((x - 0.5) % 1.0) * 2 - 1) * self.nodes["amp"]
+        return ((x - 0.5) % 1.0) * 2 - 1
 
 
 class LFTri(AGen):
@@ -559,7 +555,7 @@ class LoopAsig(AGen):
         self,
         asig: Asig | np.ndarray | str,
         rate: GenOrNum = 1,
-        gate: GeonOrNum = 1,
+        gate: GenOrNum = 1,
         start_pos: GenOrNum = 0,
         start_loop: GenOrNum = 0,
         end_loop: GenOrNum = 1,

--- a/pya/agen/lib.py
+++ b/pya/agen/lib.py
@@ -140,16 +140,17 @@ class SinOsc(SingleChannelGen):
     ----------
     freq
         The frequency of the oscillator in Hz.
-    amp
-        The amplitude of the oscillator.
     phase
         The phase of the oscillator in radians.
+    amp
+        The amplitude of the oscillator.
     """
 
     def __init__(
         self,
-        freq: GenOrNum,
+        freq: GenOrNum = 440.0,
         phase: GenOrNum = 0.0,
+        amp: GenOrNum = 1.0,
         *args,
         **kwargs,
     ):
@@ -157,6 +158,7 @@ class SinOsc(SingleChannelGen):
 
         self._add_node(freq, "freq", convert_num_to_arr=True)
         self._add_node(phase, "phase")
+        self._add_node(amp, "amp")
 
     def _generate_single(self, sample_count: int, start: int = 0) -> np.ndarray:
         m_phase = self.state.data.get("m_phase", 0)
@@ -172,7 +174,7 @@ class SinOsc(SingleChannelGen):
         x = phases[:-1] + self.nodes["phase"]
         if x.shape[0] > 0:
             self.state.data["m_phase"] = phases[-1]
-        return np.sin(x)
+        return np.sin(x) * self.nodes["amp"]
 
 
 class WhiteNoise(SingleChannelGen):
@@ -236,6 +238,61 @@ class PinkNoise(SingleChannelGen):
         return result / (10*np.sqrt(2)) # empiric scaling to match rms of sc3 PinkNoise 
 
 
+class LFImpulse(SingleChannelGen):
+    """
+    Non-band-limited single sample impulses.
+
+    Parameters
+    ----------
+    freq
+        The frequency of the oscillator in Hz. Clips at Nyquist.
+    phase
+        The phase of the oscillator in cycles (0..1).
+    amp
+        The amplitude of the oscillator.
+
+
+    LFImpulse will output a 1.0 on the first sample (assuming no phase offset).
+    If the initial freq = 0, a single impulse is output on first sample, followed by silence until the frequency changes.
+
+    """
+    def __init__(
+        self,
+        freq: GenOrNum = 440.0,
+        phase: GenOrNum = 0.0,
+        amp: GenOrNum = 1.0,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+        self._add_node(freq, "freq", convert_num_to_arr=True)
+        self._add_node(phase, "phase")
+        self._add_node(amp, "amp")
+
+    def _generate_single(self, sample_count: int, start: int = 0) -> np.ndarray:
+        m_phase = self.state.data.get("m_phase", 0)
+
+        # Use a cumsum here to account for varying frequencies
+        phases = np.cumsum(
+            np.concatenate(
+                [
+                    np.array([m_phase]),
+                    - np.minimum(self.nodes["freq"], self.sr/2) / self.sr,
+                ]
+            )
+        )
+
+        phases %= 1
+
+        if phases.shape[0] > 0:
+            self.state.data["m_phase"] = phases[-1]
+
+        phases = (phases - self.nodes["phase"]) % 1
+        # Create impulses every time the phase wraps from 0 to 1
+        return (phases[1:] > phases[:-1]) * self.nodes["amp"]
+
+
 class LFPulse(SingleChannelGen):
     """Non-band-limited Pulse Oscillator. output in [0,1]
 
@@ -291,16 +348,17 @@ class LFSaw(AGen):
     ----------
     freq
         The frequency of the oscillator in Hz.
-    amp
-        The amplitude of the oscillator.
     phase
         The initial (normalized) phase of the oscillator [0, 1].
+    amp
+        The amplitude of the oscillator.
     """
 
     def __init__(
         self,
         freq: GenOrNum,
         phase: GenOrNum = 0.0,
+        amp: GenOrNum = 1.0,
         *args,
         **kwargs,
     ) -> None:
@@ -308,6 +366,7 @@ class LFSaw(AGen):
 
         self._add_node(freq, "freq", convert_num_to_arr=True)
         self._add_node(phase, "phase")
+        self._add_node(amp, "amp")
 
     def _generate_new(self, sample_count: int, start: int, channel: int) -> np.ndarray:
         # Use a cumsum here to account for varying frequencies
@@ -324,7 +383,7 @@ class LFSaw(AGen):
         x = phases[:-1] + self.nodes["phase"]
         if x.shape[0] > 0:
             self.state.data["m_phase"] = phases[-1]
-        return ((x - 0.5) % 1.0) * 2 - 1
+        return (((x - 0.5) % 1.0) * 2 - 1) * self.nodes["amp"]
 
 
 class LFTri(AGen):

--- a/pya/agen/lib.py
+++ b/pya/agen/lib.py
@@ -160,12 +160,6 @@ class SinOsc(SingleChannelGen):
     def _generate_single(self, sample_count: int, start: int = 0) -> np.ndarray:
         m_phase = self.state.data.get("m_phase", 0)
         # Use a cumsum here to account for varying frequencies
-
-        # TODO: parity check + profiling
-        # increments = self.nodes["freq"] / self.sr * 2.0 * np.pi
-        # increments[0] += m_phase
-        # phases = np.cumsum(increments)
-
         phases = np.cumsum(
             np.concatenate(
                 [

--- a/pya/agen/lib.py
+++ b/pya/agen/lib.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import math
 import warnings
 from enum import Enum
@@ -418,6 +419,7 @@ class LFTri(AGen):
 
 def klang(
     timbre: Iterable[tuple[GenOrNum, ...]],
+    freq_scale: GenOrNum = 1.0
 ) -> AGen:
     gens = []
     for e in timbre:
@@ -428,7 +430,7 @@ def klang(
             phase = 0.0
         else:
             raise ValueError(f"Invalid timbre element: {e}")
-        gens.append(amp * SinOsc(freq=freq, phase=phase))
+        gens.append(amp * SinOsc(freq=freq*freq_scale, phase=phase))
     return AddGen(*gens)
 
 
@@ -760,6 +762,52 @@ class AsigRead(AGen):
             np.arange(sample_start, sample_start + sig.shape[0]),
             sig,
         )
+
+
+
+class AudioIn(SingleChannelGen):
+    """AudioIn generator"""
+
+    def __init__(
+        self,
+        server=None,
+        blocking=False,
+        *args,
+        **kwargs,
+    ) -> None:
+        """AudioIn reads data from Aserver inputs
+
+        Parameters
+        ----------
+        server (Aserver, optional): 
+            Aserver instance, Aserver.default as Defaults for None.
+        blocking (bool, optional): 
+            whether generation should block until new data arrives. Defaults to False.
+
+        Note that the block size is taken from server.bs. If this doesn't match
+        sample_count, the blocksize used for AGen rendering, generation will stop.
+        """
+        from pya import Aserver 
+        self.server = server if server is not None else Aserver.default
+        self.blocking = blocking
+        super().__init__(*args, **kwargs)
+
+    def _generate_single(self, sample_count: int, start: int) -> np.ndarray:
+        s = self.server
+        if s:
+            if self.blocking:
+                ct = self.state.data.get("m_block_counter", 0)
+                while s.block_cnt == ct: # this is a preliminary hack 
+                    time.sleep(0.2 * s.bs / s.sr)
+                self.state.data["m_block_counter"] = s.block_cnt
+            num_channels = s.channels
+            samples = np.frombuffer(s.latest_input, dtype=s.backend.dtype)
+            samples = samples.reshape(-1, num_channels)
+            if sample_count != s.bs:
+                print("mismatch:", sample_count, s.bs)
+            return np.squeeze(samples)
+        else:
+            return np.empty(0)
 
 
 class Line(SingleChannelGen):

--- a/pya/agen/lib.py
+++ b/pya/agen/lib.py
@@ -6,7 +6,6 @@ import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Iterable, Sequence
 import threading
-import sys
 
 import numpy as np
 from pya.asig import Asig
@@ -246,9 +245,7 @@ class LFImpulse(SingleChannelGen):
     freq
         The frequency of the oscillator in Hz. range (0Hz..Nyquist frequency).
     phase
-        The phase of the oscillator in cycles (0..1). When modulated downwards
-        faster than the phase increase of the freq, only zero-samples are returned.
-
+        The phase of the oscillator in cycles (0..1).
 
     LFImpulse will output a 1.0 on the first sample (if phase == 0).
     If the initial freq is 0, a single impulse is output on first sample, 
@@ -264,27 +261,27 @@ class LFImpulse(SingleChannelGen):
         super().__init__(*args, **kwargs)
 
         self._add_node(freq, "freq", convert_num_to_arr=True)
-        self._add_node(phase, "phase", convert_num_to_arr=True)
+        self._add_node(phase, "in_phase", convert_num_to_arr=True)
 
     def _generate_single(self, sample_count: int, start: int = 0) -> np.ndarray:
-        # To ensure first output is 1 if input phase == 0
-        m_phase = self.state.data.get("m_phase", -sys.float_info.min)
-        m_input_phase = self.state.data.get("m_input_phase", self.nodes["phase"][0]) # type: ignore
+        m_phase = self.state.data.get("m_phase", -self.nodes["freq"][0] / self.sr)
+        m_in_phase = self.state.data.get("m_in_phase", self.nodes["in_phase"][0])
 
-        # Use a cumsum here to account for varying frequencies
-        phases = np.cumsum(
-            np.concatenate(
-                ([m_phase], np.minimum(self.nodes["freq"], self.sr/2) / self.sr)
-            )
-        )
-        input_phases = np.concatenate(([m_input_phase], self.nodes["phase"]))
+        phasor = np.cumsum(np.concat(([m_phase], self.nodes["freq"] / self.sr)))        
+        phases = phasor + np.concat(([m_in_phase], self.nodes["in_phase"]))
+        floor_phases = np.floor(phases)
+        ceil_phases = np.ceil(phases)
+        result = np.logical_or(floor_phases[1:] > floor_phases[:-1], ceil_phases[1:] < ceil_phases[:-1])
 
-        self.state.data["m_phase"] = phases[-1] % 1 # modulo for long term numeric stability
-        self.state.data["m_input_phase"] = input_phases[-1]
-        
-        floor_phases = np.floor(phases + input_phases)
-        return (floor_phases[1:] > floor_phases[:-1])
+        # Special supercollider behaviour for first sample
+        if start == 0:
+            result[0] = 1 if m_in_phase % 1 == 0 else 0
 
+        self.state.data["m_phase"] = phasor[-1] % 1 # long term numeric stability
+        self.state.data["m_in_phase"] = self.nodes["in_phase"][-1]
+
+        return result.astype(float)
+    
 
 class LFPulse(SingleChannelGen):
     """Non-band-limited Pulse Oscillator. output in [0,1]


### PR DESCRIPTION
### Modulo
Added the ability to use the modulo operator `GenOrNum % GenOrNum -> AGen`.

### Functional Convenience
Added functional style functions `.mod`, `.sub`, `.div`, `.pow` as an alternative form of applying the operator.
Added functional style functions `.floor`, `.ceil`, `.round` as a short form of `.apply(...)`.

Notes: As a generic implementation for all numpy-functions as an `.apply(...)`-shortcut, a general cleanup is necessary. Especially the last three ones should be removed along many others. In the meantime they could be handy.

### LFImpulse AGen
Added an non band limited Impulse AGen.
The general behavior e.g. when modulating the phase is the same as the SuperCollider Impulse, however a sample precise parity check is yet to be done.